### PR TITLE
Added custom infix operator (=>) for defining doubles

### DIFF
--- a/Tuple2.elm
+++ b/Tuple2.elm
@@ -2,6 +2,9 @@ module Tuple2 exposing (..)
 
 {-|
 
+# Tuple definition
+@docs (=>)
+
 # Map
 @docs map, mapFst, mapSnd, mapEach, mapBoth
 
@@ -15,6 +18,20 @@ module Tuple2 exposing (..)
 @docs toList
 
 -}
+
+
+{-| Define a double with infix operator. Primarily used, when defining a List
+    with key-value Tuples.
+    
+    Dict.fromList
+        [ 0 => 'a'
+        , 1 => 'b'
+        , 2 => 'c'
+        ]
+-}
+(=>) : a -> b -> (a, b)
+(=>) a b =>
+  (a, b)
 
 
 {-| -}


### PR DESCRIPTION
I have added a custom infix operator for defining doubles(Tuples with two values).

```
(=>) : a -> b -> (a, b)
(=>) a b =>
  (a, b)

-- Usage
Dict.fromList
        [ 0 => 'a'
        , 1 => 'b'
        , 2 => 'c'
        ]
```

The original idea is from @evancz [ Elm Architecture Tutorial](https://github.com/romanzolotarev/elm-architecture-tutorial/blob/9bdbec6e9a1be99c3f5cbfb5aa2645f3c7fa8888/examples/5/RandomGif.elm#L48)
