### PR TITLE
Add Tuple.toTuple and a test with usage example in composition

### DIFF
--- a/Tuple2.elm
+++ b/Tuple2.elm
@@ -15,7 +15,7 @@ module Tuple2 exposing (..)
 @docs sort, sortBy, sortWith
 
 # Transform
-@docs toList
+@docs toList, toTuple
 
 -}
 
@@ -103,3 +103,19 @@ sortWith cmp ( a, b ) =
 toList : ( a, a ) -> List a
 toList ( a, b ) =
     [ a, b ]
+
+
+{-| Functions with multiple arguments are not convenient for composition. However converting them to a Tuple may help in some cases
+
+    type alias Model =
+        { foo : Int, bar : Int, baz : String }
+
+
+    addFooBar : Model -> Int
+    addFooBar =
+        toTuple .foo .bar
+            >> uncurry (+)
+-}
+toTuple : (a -> x) -> (a -> x_) -> a -> ( x, x_ )
+toTuple f f_ a =
+    ( f a, f_ a )

--- a/Tuple3.elm
+++ b/Tuple3.elm
@@ -14,7 +14,7 @@ module Tuple3 exposing (..)
 @docs sort, sortBy, sortWith
 
 # Transform
-@docs toList
+@docs toList, toTuple
 -}
 
 import Tuple2
@@ -132,3 +132,9 @@ swirll ( a, b, c ) =
 toList : ( a, a, a ) -> List a
 toList ( a, b, c ) =
     [ a, b, c ]
+
+
+{-| -}
+toTuple : (a -> x) -> (a -> x_) -> (a -> x__) -> a -> ( x, x_, x__ )
+toTuple f f_ f__ a =
+    ( f a, f_ a, f__ a )

--- a/Tuple4.elm
+++ b/Tuple4.elm
@@ -14,7 +14,7 @@ module Tuple4 exposing (..)
 @docs sort, sortBy, sortWith
 
 # Transform
-@docs toList
+@docs toList, toTuple
 -}
 
 import Tuple3
@@ -146,3 +146,9 @@ swirll ( a, b, c ) =
 toList : ( a, a, a, a ) -> List a
 toList ( a, b, c, d ) =
     [ a, b, c, d ]
+
+
+{-| -}
+toTuple : (a -> x) -> (a -> x_) -> (a -> x__) -> (a -> x___) -> a -> ( x, x_, x__, x___ )
+toTuple f f_ f__ f___ a =
+    ( f a, f_ a, f__ a, f___ a )

--- a/tests/Test/Tuple2.elm
+++ b/tests/Test/Tuple2.elm
@@ -2,7 +2,7 @@ module Test.Tuple2 exposing (tests)
 
 import Tuple2
 import Fuzz exposing (Fuzzer)
-import Test exposing (Test, describe, fuzz)
+import Test exposing (Test, describe, fuzz, test)
 import Expect
 
 
@@ -27,5 +27,18 @@ tests =
                         (x |> Tuple2.sort |> Tuple2.toList)
                         (x |> Tuple2.toList |> List.sort)
                 )
+            ]
+        , describe "toTuple"
+            [ test "can be used to compose a function with multiple arguments" <|
+                \() ->
+                    let
+                        myObj =
+                            { foo = 5, bar = 6, baz = 2 }
+
+                        addFooBar =
+                            Tuple2.toTuple .foo .bar
+                                >> uncurry (+)
+                    in
+                        Expect.equal (addFooBar myObj) 11
             ]
         ]


### PR DESCRIPTION
Hi.

At one point I was wondering on whether it is possible to use the composition `>>` operator in case you have functions with multiple arguments. But it's not that straight forward out of the box.

So I got the idea it would be convenient to add a function that allows you to map anything to a tuple.

Please let me know what do you think.